### PR TITLE
refactor: change indexer-rpc param to camelCase

### DIFF
--- a/packages/ckb-indexer/src/paramsFormatter.ts
+++ b/packages/ckb-indexer/src/paramsFormatter.ts
@@ -1,9 +1,26 @@
 import { Script } from "@ckb-lumos/base";
 import type * as RPCType from "./rpcType";
+import { SearchKey, SearchFilter } from "./type";
 
 const toScript = (data: Script): RPCType.Script => ({
   code_hash: data.codeHash,
   hash_type: data.hashType,
   args: data.args,
 });
-export { toScript };
+
+const toSearchFilter = (data: SearchFilter): RPCType.SearchFilter => {
+  return {
+    script: data.script ? toScript(data.script) : data.script,
+    output_data_len_range: data.outputDataLenRange,
+    output_capacity_range: data.outputCapacityRange,
+    block_range: data.blockRange,
+  };
+};
+
+const toSearchKey = (data: SearchKey): RPCType.SearchKey => ({
+  script: toScript(data.script),
+  script_type: data.scriptType,
+  filter: data.filter ? toSearchFilter(data.filter) : data.filter,
+});
+
+export { toScript, toSearchKey, toSearchFilter };

--- a/packages/ckb-indexer/src/resultFormatter.ts
+++ b/packages/ckb-indexer/src/resultFormatter.ts
@@ -1,6 +1,7 @@
 import { OutPoint, Script } from "@ckb-lumos/base";
 import type * as IndexerType from "./indexerType";
 import type * as RPCType from "./rpcType";
+import { SearchFilter, SearchKey } from "./type";
 
 const toTip = (tip: RPCType.Tip): IndexerType.Tip => ({
   blockHash: tip.block_hash,
@@ -21,4 +22,26 @@ const toCellOutPut = (data: RPCType.CellOutput): IndexerType.CellOutput => ({
   type: data.type ? toScript(data.type) : undefined,
 });
 
-export { toTip, toScript, toOutPoint, toCellOutPut };
+const toSearchFilter = (data: RPCType.SearchFilter): SearchFilter => {
+  return {
+    script: data.script ? toScript(data.script) : data.script,
+    outputDataLenRange: data.output_data_len_range,
+    outputCapacityRange: data.output_capacity_range,
+    blockRange: data.block_range,
+  };
+};
+
+const toSearchKey = (data: RPCType.SearchKey): SearchKey => ({
+  script: toScript(data.script),
+  scriptType: data.script_type,
+  filter: data.filter ? toSearchFilter(data.filter) : data.filter,
+});
+
+export {
+  toTip,
+  toScript,
+  toOutPoint,
+  toCellOutPut,
+  toSearchKey,
+  toSearchFilter,
+};

--- a/packages/ckb-indexer/src/rpc.ts
+++ b/packages/ckb-indexer/src/rpc.ts
@@ -6,6 +6,7 @@ import {
   SearchKey,
 } from "./type";
 import fetch from "cross-fetch";
+import { toSearchKey } from "./paramsFormatter";
 
 export class RPC {
   private uri: string;
@@ -27,7 +28,7 @@ export class RPC {
     limit: HexString,
     cursor?: string
   ): Promise<GetLiveCellsResult> {
-    const params = [searchKey, order, limit, cursor];
+    const params = [toSearchKey(searchKey), order, limit, cursor];
     return utils.deepCamel(await request(this.uri, "get_cells", params));
   }
   async getTransactions(
@@ -36,7 +37,7 @@ export class RPC {
     limit: HexString,
     cursor?: string
   ): Promise<IndexerTransactionList> {
-    const params = [searchKey, order, limit, cursor];
+    const params = [toSearchKey(searchKey), order, limit, cursor];
     return utils.deepCamel(await request(this.uri, "get_transactions", params));
   }
   async getIndexerInfo(): Promise<string> {

--- a/packages/ckb-indexer/src/rpcType.ts
+++ b/packages/ckb-indexer/src/rpcType.ts
@@ -1,4 +1,4 @@
-import { HexString, HexNumber, Hash } from "@ckb-lumos/base";
+import { HexString, HexNumber, Hash, Hexadecimal } from "@ckb-lumos/base";
 
 export type Tip = {
   block_hash: HexNumber;
@@ -18,3 +18,18 @@ export type CellOutput = {
   lock: Script;
   type?: Script;
 };
+
+export type HexadecimalRange = [Hexadecimal, Hexadecimal];
+export type ScriptType = "type" | "lock";
+
+export interface SearchFilter {
+  script?: Script;
+  output_data_len_range?: HexadecimalRange; //empty
+  output_capacity_range?: HexadecimalRange; //empty
+  block_range?: HexadecimalRange; //fromBlock-toBlock
+}
+export interface SearchKey {
+  script: Script;
+  script_type: ScriptType;
+  filter?: SearchFilter;
+}

--- a/packages/ckb-indexer/src/services.ts
+++ b/packages/ckb-indexer/src/services.ts
@@ -1,15 +1,10 @@
 import { utils, HexString, ScriptWrapper, Script } from "@ckb-lumos/base";
-import {
-  CKBIndexerQueryOptions,
-  HexadecimalRange,
-  SearchFilter,
-  ScriptType,
-  SearchKey,
-} from "./type";
+import { CKBIndexerQueryOptions, SearchKey } from "./type";
 import fetch from "cross-fetch";
 import { BI } from "@ckb-lumos/bi";
 import { toScript } from "./paramsFormatter";
 import type * as RPCType from "./rpcType";
+import { toSearchKey } from "./resultFormatter";
 
 function instanceOfScriptWrapper(object: unknown): object is ScriptWrapper {
   return typeof object === "object" && object != null && "script" in object;
@@ -22,8 +17,8 @@ const UnwrapScriptWrapper = (inputScript: ScriptWrapper | Script): Script => {
 };
 const generateSearchKey = (queries: CKBIndexerQueryOptions): SearchKey => {
   let script: RPCType.Script | undefined = undefined;
-  const filter: SearchFilter = {};
-  let script_type: ScriptType | undefined = undefined;
+  const filter: RPCType.SearchFilter = {};
+  let script_type: RPCType.ScriptType | undefined = undefined;
   if (queries.lock) {
     const lock = UnwrapScriptWrapper(queries.lock);
     script = toScript(lock);
@@ -37,7 +32,7 @@ const generateSearchKey = (queries: CKBIndexerQueryOptions): SearchKey => {
     script = toScript(type);
     script_type = "type";
   }
-  let block_range: HexadecimalRange | null = null;
+  let block_range: RPCType.HexadecimalRange | null = null;
   if (queries.fromBlock && queries.toBlock) {
     //toBlock+1 cause toBlock need to be included
     block_range = [
@@ -60,11 +55,11 @@ const generateSearchKey = (queries: CKBIndexerQueryOptions): SearchKey => {
   if (!script_type) {
     throw new Error("script_type must be provided");
   }
-  return {
+  return toSearchKey({
     script,
     script_type,
     filter,
-  };
+  });
 };
 
 const getHexStringBytes = (hexString: HexString): number => {

--- a/packages/ckb-indexer/src/type.ts
+++ b/packages/ckb-indexer/src/type.ts
@@ -11,7 +11,6 @@ import {
 } from "@ckb-lumos/base";
 import { EventEmitter } from "events";
 import { BIish } from "@ckb-lumos/bi";
-import type * as RPCType from "./rpcType";
 
 export type ScriptType = "type" | "lock";
 export type Order = "asc" | "desc";
@@ -24,17 +23,16 @@ export interface CKBIndexerQueryOptions extends QueryOptions {
 
 export type HexadecimalRange = [Hexadecimal, Hexadecimal];
 export interface SearchFilter {
-  script?: RPCType.Script;
-  output_data_len_range?: HexadecimalRange; //empty
-  output_capacity_range?: HexadecimalRange; //empty
-  block_range?: HexadecimalRange; //fromBlock-toBlock
+  script?: Script;
+  outputDataLenRange?: HexadecimalRange; //empty
+  outputCapacityRange?: HexadecimalRange; //empty
+  blockRange?: HexadecimalRange; //fromBlock-toBlock
 }
 export interface SearchKey {
-  script: RPCType.Script;
-  script_type: ScriptType;
+  script: Script;
+  scriptType: ScriptType;
   filter?: SearchFilter;
 }
-
 export interface GetLiveCellsResult {
   lastCursor: string;
   objects: IndexerCell[];

--- a/packages/ckb-indexer/tests/paramsFormatter.unit.test.ts
+++ b/packages/ckb-indexer/tests/paramsFormatter.unit.test.ts
@@ -1,0 +1,36 @@
+import test from "ava";
+import { toSearchKey } from "../src/paramsFormatter";
+import { SearchKey } from "../src/type";
+import type * as RPCType from "../src/rpcType";
+
+test("should toSearchKey works fine", async (t) => {
+  const query: SearchKey = {
+    script: {
+      codeHash:
+        "0x123456789012345678901234567890123456789001234567890012345678901234",
+      hashType: "data",
+      args: "0x1234567890123456789012345678901234567890",
+    },
+    scriptType: "lock",
+    filter: {
+      outputDataLenRange: ["0x1", "0x2"],
+    },
+  };
+  const expected: RPCType.SearchKey = {
+    script: {
+      args: "0x1234567890123456789012345678901234567890",
+      code_hash:
+        "0x123456789012345678901234567890123456789001234567890012345678901234",
+      hash_type: "data",
+    },
+    script_type: "lock",
+    filter: {
+      script: undefined,
+      block_range: undefined,
+      output_capacity_range: undefined,
+      output_data_len_range: ["0x1", "0x2"],
+    },
+  };
+
+  t.deepEqual(toSearchKey(query), expected);
+});

--- a/packages/ckb-indexer/tests/resultFormatter.unit.test.ts
+++ b/packages/ckb-indexer/tests/resultFormatter.unit.test.ts
@@ -1,0 +1,35 @@
+import test from "ava";
+import { toSearchKey } from "../src/resultFormatter";
+import { SearchKey } from "../src/type";
+import type * as RPCType from "../src/rpcType";
+
+test("should toSearchKey works fine", async (t) => {
+  const query: RPCType.SearchKey = {
+    script: {
+      args: "0x1234567890123456789012345678901234567890",
+      code_hash:
+        "0x123456789012345678901234567890123456789001234567890012345678901234",
+      hash_type: "data",
+    },
+    script_type: "lock",
+    filter: {
+      output_data_len_range: ["0x1", "0x2"],
+    },
+  };
+  const expected: SearchKey = {
+    script: {
+      codeHash:
+        "0x123456789012345678901234567890123456789001234567890012345678901234",
+      hashType: "data",
+      args: "0x1234567890123456789012345678901234567890",
+    },
+    scriptType: "lock",
+    filter: {
+      script: undefined,
+      outputCapacityRange: undefined,
+      blockRange: undefined,
+      outputDataLenRange: ["0x1", "0x2"],
+    },
+  };
+  t.deepEqual(toSearchKey(query), expected);
+});

--- a/packages/ckb-indexer/tests/service.unit.test.ts
+++ b/packages/ckb-indexer/tests/service.unit.test.ts
@@ -1,0 +1,33 @@
+import test from "ava";
+import { SearchKey } from "../src/type";
+import { generateSearchKey } from "../src/services";
+
+test("should generateSearchKey works fine", async (t) => {
+  const expected: SearchKey = {
+    script: {
+      codeHash:
+        "0x123456789012345678901234567890123456789001234567890012345678901234",
+      hashType: "data",
+      args: "0x1234567890123456789012345678901234567890",
+    },
+    scriptType: "lock",
+    filter: {
+      script: undefined,
+      outputCapacityRange: undefined,
+      blockRange: undefined,
+      outputDataLenRange: ["0x1", "0x2"],
+    },
+  };
+  t.deepEqual(
+    generateSearchKey({
+      lock: {
+        codeHash:
+          "0x123456789012345678901234567890123456789001234567890012345678901234",
+        hashType: "data",
+        args: "0x1234567890123456789012345678901234567890",
+      },
+      outputDataLenRange: ["0x1", "0x2"],
+    }),
+    expected
+  );
+});

--- a/website/docs/migrations/migrate-to-v0.19.md
+++ b/website/docs/migrations/migrate-to-v0.19.md
@@ -22,7 +22,7 @@ Running the codemod will:
 2. show warnings for deprecated functions.
 
 ```sh
-curl -s https://gist.githubusercontent.com/zhangyouxin/e5ddf9b966f611173a01d6c98715c931/raw/30606c12756a866437a390add8dc5f5df47c9c36/codemod.js \
+curl -s https://gist.githubusercontent.com/zhangyouxin/e5ddf9b966f611173a01d6c98715c931/raw \
 | xargs -0 -I{} node -e {} "your-source-dir/**/*.js"
 ```
 
@@ -56,12 +56,13 @@ Rewrite Serialization and DeSerialization codes.
 +    witness = bytes.hexify(blockchain.WitnessArgs.pack(newWitnessArgs))
 ```
 
-### Step 3 - Utility Functions in `@ckb-lumos/base/utils`
+### Step 3 - Misc
 
 Some other changes you should take care of.
 
 - removed `digestReader` of `CKBHasher` class in `@ckb-lumos/base/utils`
 - return type of `ckbhash` function has changed to `HexString`
+- `blockchain` exposed in `@ckb-lumos/codec` has been moved to `@ckb-lumos/base`
 
 ```diff
   const hasher = new CKBHasher()
@@ -71,6 +72,9 @@ Some other changes you should take care of.
   // if you would like to manipulate ArrayBuffer
 + import { bytes } from "@ckb-lumos/codec"
 + const messageBytes = bytes.bytify(message)
+  // blockchain has been moved
+- import { blockchain } from "@ckb-lumos/codec"
++ import { blockchain } from "@ckb-lumos/base"
 ```
 
 After doing the 3 steps, you have done migrating to v0.19.


### PR DESCRIPTION
This pr has:

- change `SearchKey` of indexer-rpc methods params to camelCase
- added test cases