### PR TITLE
feat: add molecule  sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ packages/hd-cache/lib
 packages/rpc/lib
 packages/bi/lib
 packages/experiment-tx-assembler/lib
+packages/molecule/lib
 
 # knex config
 packages/sql-indexer/knexfile.ts

--- a/packages/base/src/blockchain.ts
+++ b/packages/base/src/blockchain.ts
@@ -11,7 +11,7 @@ import {
 } from "@ckb-lumos/codec";
 import { BytesCodec, FixedBytesCodec } from "@ckb-lumos/codec/lib/base";
 
-import type * as api from './api';
+import type * as api from "./api";
 import { BI } from "@ckb-lumos/bi";
 
 const { Uint128LE, Uint8, Uint32LE, Uint64LE } = number;
@@ -20,8 +20,10 @@ const { bytify, hexify } = bytes;
 
 type TransactionCodecType = PackParam<typeof BaseTransaction>;
 type TransactionUnpackResultType = UnpackResult<typeof BaseTransaction>;
+type RawTransactionUnpackResultType = UnpackResult<typeof RawTransaction>;
 type HeaderCodecType = PackParam<typeof BaseHeader>;
 type HeaderUnpackResultType = UnpackResult<typeof BaseHeader>;
+type RawHeaderUnpackResultType = UnpackResult<typeof RawHeader>;
 
 export function createFixedHexBytesCodec(
   byteLength: number
@@ -250,7 +252,8 @@ export const BaseHeader = struct(
 );
 
 export const Header = createBytesCodec({
-  pack: (header: api.Header) => BaseHeader.pack(transformHeaderCodecType(header)),
+  pack: (header: api.Header) =>
+    BaseHeader.pack(transformHeaderCodecType(header)),
   unpack: (buf) => deTransformHeaderCodecType(BaseHeader.unpack(buf)),
 });
 
@@ -345,13 +348,13 @@ export function transformTransactionCodecType(
 
 export function deTransformTransactionCodecType(
   data: TransactionUnpackResultType
-): api.Transaction {
+): RawTransactionUnpackResultType & { witnesses: string[] } {
   return {
     cellDeps: data.raw.cellDeps.map((cellDep) => {
       return {
         outPoint: {
           txHash: cellDep.outPoint.txHash,
-          index: BI.from(cellDep.outPoint.index).toHexString(),
+          index: cellDep.outPoint.index,
         },
         depType: cellDep.depType,
       };
@@ -361,20 +364,20 @@ export function deTransformTransactionCodecType(
       return {
         previousOutput: {
           txHash: input.previousOutput.txHash,
-          index: BI.from(input.previousOutput.index).toHexString(),
+          index: input.previousOutput.index,
         },
-        since: input.since.toHexString(),
+        since: input.since,
       };
     }),
     outputs: data.raw.outputs.map((output) => {
       return {
-        capacity: output.capacity.toHexString(),
+        capacity: output.capacity,
         lock: output.lock,
         type: output.type,
       };
     }),
     outputsData: data.raw.outputsData,
-    version: BI.from(data.raw.version).toHexString(),
+    version: data.raw.version,
     witnesses: data.witnesses,
   };
 }
@@ -399,19 +402,19 @@ export function transformHeaderCodecType(data: api.Header): HeaderCodecType {
 
 export function deTransformHeaderCodecType(
   data: HeaderUnpackResultType
-): api.Header {
+): RawHeaderUnpackResultType & { nonce: BI; hash: string } {
   return {
-    timestamp: data.raw.timestamp.toHexString(),
-    number: data.raw.number.toHexString(),
-    epoch: data.raw.epoch.toHexString(),
-    compactTarget: BI.from(data.raw.compactTarget).toHexString(),
+    timestamp: data.raw.timestamp,
+    number: data.raw.number,
+    epoch: data.raw.epoch,
+    compactTarget: data.raw.compactTarget,
     dao: data.raw.dao,
     parentHash: data.raw.parentHash,
     proposalsHash: data.raw.proposalsHash,
     transactionsRoot: data.raw.transactionsRoot,
     extraHash: data.raw.extraHash,
-    version: BI.from(data.raw.version).toHexString(),
-    nonce: data.nonce.toHexString(),
+    version: data.raw.version,
+    nonce: data.nonce,
     hash: "",
   };
 }

--- a/packages/base/tests/deserialize.test.ts
+++ b/packages/base/tests/deserialize.test.ts
@@ -1,0 +1,313 @@
+import test from "ava";
+import { deepHexifyBI } from "@ckb-lumos/codec/lib/utils";
+import * as blockchain from "../src/blockchain";
+import type * as api from "../src/api";
+import { BI } from "@ckb-lumos/bi";
+
+test("unpack script", (t) => {
+  const value: api.Script = {
+    codeHash:
+      "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+    args: "0xaabbccdd44332211",
+    hashType: "type",
+  };
+  const data =
+    "0x3d0000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce80108000000aabbccdd44332211";
+  const unpacked = blockchain.Script.unpack(data);
+  t.deepEqual(value, unpacked);
+});
+
+test("unpack outpoint", (t) => {
+  const value = {
+    txHash:
+      "0x4565f957aa65ca5d094ede05cbeaedcee70f5a71200ae2e31b643d2952c929bc",
+    index: BI.from("0x03").toNumber(),
+  };
+  const data =
+    "0x4565f957aa65ca5d094ede05cbeaedcee70f5a71200ae2e31b643d2952c929bc03000000";
+  const unpacked = blockchain.OutPoint.unpack(data);
+  t.deepEqual(unpacked, value);
+});
+
+test("unpack cellinput", (t) => {
+  const value = {
+    since: "0x60a0001234",
+    previousOutput: {
+      txHash:
+        "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da",
+      index: 16,
+    },
+  };
+  const data =
+    "0x341200a060000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da10000000";
+  const unpacked = deepHexifyBI(blockchain.CellInput.unpack(data));
+  t.deepEqual(unpacked, value);
+});
+
+test("unpack celloutput", (t) => {
+  const value = {
+    capacity: "0x10",
+    lock: {
+      codeHash:
+        "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da",
+      args: "0x1234",
+      hashType: "data",
+    },
+    type: {
+      codeHash:
+        "0xa98c57135830e1b900000000f6c4b8870828199a786b26f09f7dec4bc27a73db",
+      args: "0x",
+      hashType: "type",
+    },
+  };
+  const data =
+    "0x8400000010000000180000004f000000100000000000000037000000100000003000000031000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da0002000000123435000000100000003000000031000000a98c57135830e1b900000000f6c4b8870828199a786b26f09f7dec4bc27a73db0100000000";
+  const unpacked = deepHexifyBI(blockchain.CellOutput.unpack(data));
+
+  t.deepEqual(unpacked, value);
+});
+
+test("unpack celloutput without type", (t) => {
+  const value = {
+    capacity: "0x10",
+    lock: {
+      codeHash:
+        "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da",
+      args: "0x1234",
+      hashType: "data",
+    },
+    type: undefined,
+  };
+  const data =
+    "0x4f00000010000000180000004f000000100000000000000037000000100000003000000031000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da00020000001234";
+  const unpacked = deepHexifyBI(blockchain.CellOutput.unpack(data));
+  t.deepEqual(unpacked, value);
+});
+
+test("unpack celldep", (t) => {
+  const value = {
+    depType: "code",
+    outPoint: {
+      txHash:
+        "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da",
+      index: 17,
+    },
+  };
+  const data =
+    "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da1100000000";
+  const unpacked = deepHexifyBI(blockchain.CellDep.unpack(data));
+
+  t.deepEqual(unpacked, value);
+});
+
+test("unpack transaction", (t) => {
+  const value = {
+    version: 0,
+    cellDeps: [
+      {
+        depType: "code",
+        outPoint: {
+          txHash:
+            "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7300",
+          index: 0,
+        },
+      },
+    ],
+    headerDeps: [
+      "0xb39d53656421d1532dd995a0924441ca8f43052bc2b7740a0e814a488a8214d6",
+    ],
+    inputs: [
+      {
+        since: "0x10",
+        previousOutput: {
+          txHash:
+            "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7301",
+          index: 2,
+        },
+      },
+    ],
+    outputs: [
+      {
+        capacity: "0x1234",
+        lock: {
+          codeHash:
+            "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7302",
+          args: "0x1234",
+          hashType: "data",
+        },
+        type: undefined,
+      },
+    ],
+    outputsData: ["0xabcdef"],
+    witnesses: ["0x31313131"],
+  };
+  const data =
+    "0x1f0100000c0000000f010000030100001c00000020000000490000006d0000009d000000f40000000000000001000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7300000000000001000000b39d53656421d1532dd995a0924441ca8f43052bc2b7740a0e814a488a8214d6010000001000000000000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73010200000057000000080000004f00000010000000180000004f000000341200000000000037000000100000003000000031000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7302000200000012340f0000000800000003000000abcdef10000000080000000400000031313131";
+  const unpacked = deepHexifyBI(blockchain.Transaction.unpack(data));
+
+  t.deepEqual(unpacked, value);
+});
+
+test("unpack header", (t) => {
+  const value = {
+    compactTarget: 439170196,
+    number: "0xfb1bc",
+    parentHash:
+      "0x3134874027b9b2b17391d2fa545344b10bd8b8c49d9ea47d55a447d01142b21b",
+    nonce: "0x449b385049af131a0000001584a00100",
+    timestamp: "0x170aba663c3",
+    transactionsRoot:
+      "0x68a83c880eb942396d22020aa83343906986f66418e9b8a4488f2866ecc4e86a",
+    proposalsHash:
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+    extraHash:
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+    version: 0,
+    epoch: "0x7080612000287",
+    dao: "0x40b4d9a3ddc9e730736c7342a2f023001240f362253b780000b6ca2f1e790107",
+    hash: "",
+  };
+  const data =
+    "0x0000000094342d1ac363a6ab70010000bcb10f000000000087020012060807003134874027b9b2b17391d2fa545344b10bd8b8c49d9ea47d55a447d01142b21b68a83c880eb942396d22020aa83343906986f66418e9b8a4488f2866ecc4e86a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040b4d9a3ddc9e730736c7342a2f023001240f362253b780000b6ca2f1e7901070001a084150000001a13af4950389b44";
+  const unpacked = deepHexifyBI(blockchain.Header.unpack(data));
+
+  t.deepEqual(unpacked, value);
+});
+
+test("unpack uncle block", (t) => {
+  const value = {
+    header: {
+      compactTarget: 439170196,
+      number: "0xfb1bc",
+      parentHash:
+        "0x3134874027b9b2b17391d2fa545344b10bd8b8c49d9ea47d55a447d01142b21b",
+      nonce: "0x449b385049af131a0000001584a00100",
+      timestamp: "0x170aba663c3",
+      transactionsRoot:
+        "0x68a83c880eb942396d22020aa83343906986f66418e9b8a4488f2866ecc4e86a",
+      proposalsHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+      extraHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+      version: 0,
+      epoch: "0x7080612000287",
+      dao: "0x40b4d9a3ddc9e730736c7342a2f023001240f362253b780000b6ca2f1e790107",
+      hash: "",
+    },
+    proposals: ["0x12345678901234567890", "0xabcdeabcdeabcdeabcde"],
+  };
+  const data =
+    "0xf40000000c000000dc0000000000000094342d1ac363a6ab70010000bcb10f000000000087020012060807003134874027b9b2b17391d2fa545344b10bd8b8c49d9ea47d55a447d01142b21b68a83c880eb942396d22020aa83343906986f66418e9b8a4488f2866ecc4e86a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040b4d9a3ddc9e730736c7342a2f023001240f362253b780000b6ca2f1e7901070001a084150000001a13af4950389b440200000012345678901234567890abcdeabcdeabcdeabcde";
+  const unpacked = deepHexifyBI(blockchain.UncleBlock.unpack(data));
+
+  t.deepEqual(unpacked, value);
+});
+
+test("unpack block", (t) => {
+  const value = {
+    header: {
+      compactTarget: 439170196,
+      number: "0xfb1bc",
+      parentHash:
+        "0x3134874027b9b2b17391d2fa545344b10bd8b8c49d9ea47d55a447d01142b21b",
+      nonce: "0x449b385049af131a0000001584a00100",
+      timestamp: "0x170aba663c3",
+      transactionsRoot:
+        "0x68a83c880eb942396d22020aa83343906986f66418e9b8a4488f2866ecc4e86a",
+      proposalsHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+      extraHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+      version: 0,
+      epoch: "0x7080612000287",
+      dao: "0x40b4d9a3ddc9e730736c7342a2f023001240f362253b780000b6ca2f1e790107",
+      hash: "",
+    },
+    transactions: [
+      {
+        version: 0,
+        cellDeps: [
+          {
+            depType: "code",
+            outPoint: {
+              txHash:
+                "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7300",
+              index: 0,
+            },
+          },
+        ],
+        headerDeps: [
+          "0xb39d53656421d1532dd995a0924441ca8f43052bc2b7740a0e814a488a8214d6",
+        ],
+        inputs: [
+          {
+            since: "0x10",
+            previousOutput: {
+              txHash:
+                "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7301",
+              index: 2,
+            },
+          },
+        ],
+        outputs: [
+          {
+            capacity: "0x1234",
+            lock: {
+              codeHash:
+                "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7302",
+              args: "0x1234",
+              hashType: "data",
+            },
+            type: undefined,
+          },
+        ],
+        outputsData: ["0xabcdef"],
+        witnesses: ["0x1111"],
+      },
+    ],
+    uncles: [],
+    proposals: ["0x12345678901234567890", "0xabcdeabcdeabcdeabcde"],
+  };
+  const data =
+    "0x2502000014000000e4000000e80000000d0200000000000094342d1ac363a6ab70010000bcb10f000000000087020012060807003134874027b9b2b17391d2fa545344b10bd8b8c49d9ea47d55a447d01142b21b68a83c880eb942396d22020aa83343906986f66418e9b8a4488f2866ecc4e86a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040b4d9a3ddc9e730736c7342a2f023001240f362253b780000b6ca2f1e7901070001a084150000001a13af4950389b440400000025010000080000001d0100000c0000000f010000030100001c00000020000000490000006d0000009d000000f40000000000000001000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7300000000000001000000b39d53656421d1532dd995a0924441ca8f43052bc2b7740a0e814a488a8214d6010000001000000000000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73010200000057000000080000004f00000010000000180000004f000000341200000000000037000000100000003000000031000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7302000200000012340f0000000800000003000000abcdef0e000000080000000200000011110200000012345678901234567890abcdeabcdeabcdeabcde";
+  const unpacked = deepHexifyBI(blockchain.Block.unpack(data));
+
+  t.deepEqual(unpacked, value);
+});
+
+test("serialize witness args", (t) => {
+  const value = {
+    lock: "0x1234",
+    inputType: "0x4678",
+    outputType: "0x2312",
+  };
+  const data =
+    "0x2200000010000000160000001c000000020000001234020000004678020000002312";
+  const unpacked = deepHexifyBI(blockchain.WitnessArgs.unpack(data));
+
+  t.deepEqual(unpacked, value);
+});
+
+test("unpack empty witness args", (t) => {
+  const value = {
+    lock: undefined,
+    inputType: undefined,
+    outputType: undefined,
+  };
+  const data = "0x10000000100000001000000010000000";
+  const unpacked = deepHexifyBI(blockchain.WitnessArgs.unpack(data));
+
+  t.deepEqual(unpacked, value);
+});
+
+test("unpack only one witness args", (t) => {
+  const value = {
+    lock: "0x1234",
+    inputType: undefined,
+    outputType: undefined,
+  };
+  const data = "0x16000000100000001600000016000000020000001234";
+  const unpacked = deepHexifyBI(blockchain.WitnessArgs.unpack(data));
+
+  t.deepEqual(unpacked, value);
+});

--- a/packages/codec/src/utils.ts
+++ b/packages/codec/src/utils.ts
@@ -3,6 +3,80 @@ import {
   CodecExecuteError,
   isCodecExecuteError,
 } from "./error";
+import { BI } from "@ckb-lumos/bi";
+
+export type UnpackType =
+  | string
+  | number
+  | BI
+  | undefined
+  | { [property: string]: UnpackType }
+  | UnpackType[];
+
+export type BITranslatedUnpackType =
+  | string
+  | number
+  | undefined
+  | { [property: string]: BITranslatedUnpackType }
+  | BITranslatedUnpackType[];
+
+export const deepTranslateBI =
+  (fnName: keyof BI) =>
+  (data: UnpackType): BITranslatedUnpackType => {
+    if (
+      Object.prototype.toString.call(data) === "[object Number]" ||
+      Object.prototype.toString.call(data) === "[object String]"
+    ) {
+      return data as number | string;
+    } else if (Object.prototype.toString.call(data) === "[object Object]") {
+      const isBI = BI.isBI(data);
+
+      if (isBI) {
+        return (BI.prototype[fnName] as () => string).call(data);
+      }
+      const keys = Object.keys(data as Record<string, unknown>);
+      let result: Record<string, unknown> = {};
+      keys.forEach((key) => {
+        const value = (data as Record<string, UnpackType>)[key];
+        // TODO: not sure if there is a performance issue
+        result = Object.assign(result, {
+          [key]: deepTranslateBI(fnName)(value),
+        });
+      });
+      return result as BITranslatedUnpackType;
+    } else if (Object.prototype.toString.call(data) === "[object Array]") {
+      // TODO: not sure if there is a performance issue
+      return (data as BITranslatedUnpackType[]).map((item) =>
+        deepTranslateBI(fnName)(item)
+      );
+    } else if (Object.prototype.toString.call(data) === "[object Undefined]") {
+      return undefined;
+    } else {
+      throw new Error(
+        `UnpackType should not contain types other than string|number|object|array|undefined. recieved ${JSON.stringify(
+          data
+        )}, type is ${Object.prototype.toString.call(data)}`
+      );
+    }
+  };
+
+/**
+ * Unpack result is either number, string, object, or BI
+ * convert { field: BI } to { field: HexString } in order to compare unpack results in tests
+ *
+ * e.g. { capacity: BI.from(10) } ==> { capacity: "0xa" }
+ * @param data
+ */
+export const deepHexifyBI = deepTranslateBI("toHexString");
+
+/**
+ * Unpack result is either number, string, object, or BI
+ * convert { field: BI } to { field: string } in order to compare unpack results in tests
+ *
+ * e.g. { capacity: BI.from(10) } ==> { capacity: "10" }
+ * @param data
+ */
+export const deepDecimalizeBI = deepTranslateBI("toString");
 
 const HEX_DECIMAL_REGEX = /^0x([0-9a-fA-F])+$/;
 const HEX_DECIMAL_WITH_BYTELENGTH_REGEX_MAP = new Map<number, RegExp>();
@@ -11,9 +85,7 @@ export function assertHexDecimal(str: string, byteLength?: number): void {
   if (byteLength) {
     let regex = HEX_DECIMAL_WITH_BYTELENGTH_REGEX_MAP.get(byteLength);
     if (!regex) {
-      const newRegex = RegExp(
-        String.raw`^0x([0-9a-fA-F]){1,${byteLength * 2}}$`
-      );
+      const newRegex = new RegExp(`^0x([0-9a-fA-F]){1,${byteLength * 2}}$`);
       HEX_DECIMAL_WITH_BYTELENGTH_REGEX_MAP.set(byteLength, newRegex);
       regex = newRegex;
     }
@@ -34,8 +106,8 @@ export function assertHexString(str: string, byteLength?: number): void {
   if (byteLength) {
     let regex = HEX_STRING_WITH_BYTELENGTH_REGEX_MAP.get(byteLength);
     if (!regex) {
-      const newRegex = RegExp(
-        String.raw`^0x([0-9a-fA-F][0-9a-fA-F]){${byteLength}}$`
+      const newRegex = new RegExp(
+        `^0x([0-9a-fA-F][0-9a-fA-F]){${byteLength}}$`
       );
       HEX_STRING_WITH_BYTELENGTH_REGEX_MAP.set(byteLength, newRegex);
       regex = newRegex;

--- a/packages/codec/tests/utils.test.ts
+++ b/packages/codec/tests/utils.test.ts
@@ -1,6 +1,134 @@
 import test from "ava";
-import { assertHexDecimal, assertHexString, isObjectLike } from "../src/utils";
+import {
+  assertHexDecimal,
+  assertHexString,
+  isObjectLike,
+  deepHexifyBI,
+  deepDecimalizeBI,
+} from "../src/utils";
 import { bytify } from "../src/bytes";
+import { BI } from "@ckb-lumos/lumos";
+
+test("test codec", (t) => {
+  const tx = {
+    version: "0x0",
+    cellDeps: [
+      {
+        depType: "code",
+        outPoint: {
+          txHash:
+            "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7300",
+          index: BI.from("0x0"),
+        },
+      },
+    ],
+    headerDeps: [
+      "0xb39d53656421d1532dd995a0924441ca8f43052bc2b7740a0e814a488a8214d6",
+    ],
+    inputs: [
+      {
+        since: BI.from("0x10"),
+        previousOutput: {
+          txHash:
+            "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7301",
+          index: BI.from("0x2"),
+        },
+      },
+    ],
+    outputs: [
+      {
+        capacity: BI.from("0x1234"),
+        lock: {
+          codeHash:
+            "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7302",
+          args: "0x1234",
+          hashType: "data",
+        },
+      },
+    ],
+    outputsData: ["0xabcdef"],
+    witnesses: ["0x31313131"],
+  };
+  t.deepEqual(deepHexifyBI(tx), {
+    version: "0x0",
+    cellDeps: [
+      {
+        depType: "code",
+        outPoint: {
+          txHash:
+            "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7300",
+          index: "0x0",
+        },
+      },
+    ],
+    headerDeps: [
+      "0xb39d53656421d1532dd995a0924441ca8f43052bc2b7740a0e814a488a8214d6",
+    ],
+    inputs: [
+      {
+        since: "0x10",
+        previousOutput: {
+          txHash:
+            "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7301",
+          index: "0x2",
+        },
+      },
+    ],
+    outputs: [
+      {
+        capacity: "0x1234",
+        lock: {
+          codeHash:
+            "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7302",
+          args: "0x1234",
+          hashType: "data",
+        },
+      },
+    ],
+    outputsData: ["0xabcdef"],
+    witnesses: ["0x31313131"],
+  });
+
+  t.deepEqual(deepDecimalizeBI(tx), {
+    version: "0x0",
+    cellDeps: [
+      {
+        depType: "code",
+        outPoint: {
+          txHash:
+            "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7300",
+          index: "0",
+        },
+      },
+    ],
+    headerDeps: [
+      "0xb39d53656421d1532dd995a0924441ca8f43052bc2b7740a0e814a488a8214d6",
+    ],
+    inputs: [
+      {
+        since: "16",
+        previousOutput: {
+          txHash:
+            "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7301",
+          index: "2",
+        },
+      },
+    ],
+    outputs: [
+      {
+        capacity: "4660",
+        lock: {
+          codeHash:
+            "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7302",
+          args: "0x1234",
+          hashType: "data",
+        },
+      },
+    ],
+    outputsData: ["0xabcdef"],
+    witnesses: ["0x31313131"],
+  });
+});
 
 test("should assertHexString fail", (t) => {
   t.throws(() => assertHexString("00"));

--- a/packages/lumos/package.json
+++ b/packages/lumos/package.json
@@ -45,7 +45,8 @@
     "@ckb-lumos/hd": "^0.19.0-alpha.3",
     "@ckb-lumos/helpers": "^0.19.0-alpha.3",
     "@ckb-lumos/rpc": "^0.19.0-alpha.3",
-    "@ckb-lumos/toolkit": "^0.19.0-alpha.3"
+    "@ckb-lumos/toolkit": "^0.19.0-alpha.3",
+    "@ckb-lumos/molecule": "^0.19.0-alpha.3"
   },
   "devDependencies": {
     "buffer": "^6.0.3",

--- a/packages/lumos/src/index.ts
+++ b/packages/lumos/src/index.ts
@@ -46,3 +46,4 @@ export { CellCollector, Indexer } from "@ckb-lumos/ckb-indexer";
 export * as helpers from "@ckb-lumos/helpers";
 export * as commons from "@ckb-lumos/common-scripts";
 export { BI } from "@ckb-lumos/bi";
+export * as molecule from "@ckb-lumos/molecule";

--- a/packages/molecule/package.json
+++ b/packages/molecule/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@ckb-lumos/molecule",
+  "version": "0.19.0-alpha.3",
+  "description": "Molecule parser for CKB",
+  "homepage": "https://github.com/ckb-js/lumos#readme",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "engines": {
+    "node": ">=12.0.0"
+  },
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ckb-js/lumos.git"
+  },
+  "ava": {
+    "extensions": [
+      "ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ]
+  },
+  "bugs": {
+    "url": "https://github.com/ckb-js/lumos/issues"
+  },
+  "scripts": {
+    "test": "ava **/*.test.ts --timeout=2m",
+    "fmt": "prettier --write \"{src,tests,examples}/**/*.ts\" package.json",
+    "lint": "eslint -c ../../.eslintrc.js \"{src,tests,examples}/**/*.ts\"",
+    "build": "npm run build:types && npm run build:js",
+    "build:types": "tsc --declaration --emitDeclarationOnly",
+    "build:js": "babel --root-mode upward src --out-dir lib --extensions .ts -s && npm run build:old",
+    "build:old": "shx mkdir -p lib/grammar && shx cp -r src/grammar/*.js lib/grammar ",
+    "clean": "rm -rf lib",
+    "prepublishOnly": "yarn run clean && yarn run build",
+    "release": "npm publish"
+  },
+  "dependencies": {
+    "@ckb-lumos/bi": "^0.19.0-alpha.3",
+    "@ckb-lumos/codec": "^0.19.0-alpha.3",
+    "@types/nearley": "^2.11.2",
+    "moo": "^0.5.1",
+    "nearley": "^2.20.1"
+  },
+  "devDependencies": {
+    "shx": "^0.3.4"
+  }
+}

--- a/packages/molecule/src/codec.ts
+++ b/packages/molecule/src/codec.ts
@@ -1,0 +1,190 @@
+import {
+  FixedBytesCodec,
+  createBytesCodec,
+  BytesLike,
+  BytesCodec,
+} from "@ckb-lumos/codec/lib/base";
+import {
+  array,
+  byteVecOf,
+  option,
+  struct,
+  table,
+  union,
+  vector,
+} from "@ckb-lumos/codec/lib/molecule";
+import { createFixedHexBytesCodec } from "@ckb-lumos/codec/lib/blockchain";
+import { byte, CodecMap, MolType, MolTypeMap } from "./type";
+import { nonNull, toMolTypeMap } from "./utils";
+import { bytes, number } from "@ckb-lumos/codec";
+
+function createHexBytesCodec(): BytesCodec<string, BytesLike> {
+  return createBytesCodec({
+    pack: (hex) => bytes.bytify(hex),
+    unpack: (buf) => bytes.hexify(buf),
+  });
+}
+
+/**
+ * Add corresponding type and its depencies to result, then return coressponding codec
+ * @param key
+ * @param molTypeMap
+ * @param result
+ * @returns codec
+ */
+export const toCodec = (
+  key: string,
+  molTypeMap: MolTypeMap,
+  result: CodecMap,
+  refs?: CodecMap
+): BytesCodec => {
+  if (result.has(key)) {
+    return result.get(key)!;
+  }
+  if (refs?.has(key)) {
+    return refs.get(key)!;
+  }
+  const molType: MolType = molTypeMap.get(key)!;
+  nonNull(molType);
+  let codec = null;
+  switch (molType.type) {
+    case "array": {
+      if (molType.name.startsWith("Uint")) {
+        switch (molType.name) {
+          case "Uint8":
+            codec = number.Uint8;
+            break;
+          case "Uint16":
+            codec = number.Uint16;
+            break;
+          case "Uint32":
+            codec = number.Uint32;
+            break;
+          case "Uint64":
+            codec = number.Uint64;
+            break;
+          case "Uint128":
+            codec = number.Uint128;
+            break;
+          case "Uint256":
+            codec = number.Uint256;
+            break;
+          case "Uint512":
+            codec = number.Uint512;
+            break;
+          default:
+            throw new Error(
+              `Number codecs should be among Uint8,Uint8,Uint8,Uint8,Uint8,Uint8,Uint8 but got ${molType.name}.`
+            );
+        }
+      } else if (molType.item === byte) {
+        codec = createFixedHexBytesCodec(molType.item_count);
+      } else {
+        const itemMolType = toCodec(molType.item, molTypeMap, result, refs);
+        codec = array(itemMolType as FixedBytesCodec, molType.item_count);
+      }
+      break;
+    }
+    case "vector": {
+      if (molType.item === byte) {
+        codec = byteVecOf(createHexBytesCodec());
+      } else {
+        const itemMolType = toCodec(molType.item, molTypeMap, result, refs);
+        codec = vector(itemMolType);
+      }
+      break;
+    }
+    case "option": {
+      if (molType.item === byte) {
+        codec = option(createFixedHexBytesCodec(1));
+      } else {
+        const itemMolType = toCodec(molType.item, molTypeMap, result, refs);
+        codec = option(itemMolType);
+      }
+      break;
+    }
+    case "union": {
+      const unionCodecs: Record<string, BytesCodec> = {};
+      molType.items.forEach((itemMolTypeName) => {
+        if (itemMolTypeName === byte) {
+          unionCodecs[itemMolTypeName] = createFixedHexBytesCodec(1);
+        } else {
+          const itemMolType = toCodec(
+            itemMolTypeName,
+            molTypeMap,
+            result,
+            refs
+          );
+          unionCodecs[itemMolTypeName] = itemMolType;
+        }
+      });
+      codec = union(unionCodecs, Object.keys(unionCodecs));
+      break;
+    }
+    case "table": {
+      const tableFields = molType.fields;
+      const tableCodecs: Record<string, BytesCodec> = {};
+      tableFields.forEach((field) => {
+        if (field.type === byte) {
+          tableCodecs[field.name] = createFixedHexBytesCodec(1);
+        } else {
+          const itemMolType = toCodec(field.type, molTypeMap, result, refs);
+          tableCodecs[field.name] = itemMolType;
+        }
+      });
+      codec = table(
+        tableCodecs,
+        tableFields.map((field) => field.name)
+      );
+      break;
+    }
+    case "struct": {
+      const structFields = molType.fields;
+      const structCodecs: Record<string, FixedBytesCodec> = {};
+      structFields.forEach((field) => {
+        if (field.type === byte) {
+          structCodecs[field.name] = createFixedHexBytesCodec(1);
+        } else {
+          const itemMolType = toCodec(field.type, molTypeMap, result, refs);
+          structCodecs[field.name] = itemMolType as FixedBytesCodec;
+        }
+      });
+      codec = struct(
+        structCodecs,
+        structFields.map((field) => field.name)
+      );
+      break;
+    }
+    default:
+      throw new Error(`Not supportted molecule type ${molType}.`);
+  }
+  nonNull(codec);
+  if (!result.has(key)) {
+    result.set(key, codec);
+  } else {
+    console.error(`Existing codec: ${key} has been added to result.`);
+  }
+  return codec;
+};
+
+/**
+ * create Codecs from tokens
+ * @param molTypeMap
+ * @returns
+ */
+export const createCodecMap = (
+  molTypeInfo: MolTypeMap | MolType[],
+  refs?: CodecMap
+): CodecMap => {
+  const molTypeMap = ((data) => {
+    if (Array.isArray(data)) {
+      return toMolTypeMap(data as MolType[]);
+    }
+    return data as MolTypeMap;
+  })(molTypeInfo);
+  const result = new Map<string, BytesCodec>();
+  for (const entry of molTypeMap) {
+    toCodec(entry[0], molTypeMap, result, refs);
+  }
+  return result;
+};

--- a/packages/molecule/src/grammar/mol.js
+++ b/packages/molecule/src/grammar/mol.js
@@ -1,0 +1,527 @@
+/* eslint-disable */
+// Generated automatically by nearley, version 2.20.1
+// http://github.com/Hardmath123/nearley
+(function () {
+  function id(x) {
+    return x[0];
+  }
+
+  const moo = require("moo");
+
+  const lexer = moo.compile({
+    ws: /[ \t]+/,
+    nl: { match: "\n", lineBreaks: true },
+    lparan: "(",
+    rparan: ")",
+    comma: ",",
+    lbracket: "[",
+    rbracket: "]",
+    lbrace: "{",
+    rbrace: "}",
+    labracket: "<",
+    rabracket: ">",
+    assignment: "=",
+    colon: ":",
+    semicolon: ";",
+    line_comment: {
+      match: /\/\/[^\n]*/,
+      value: (s) => s.substring(1),
+    },
+    block_comment: {
+      match: /\/\*[\w\d\s\n\t\r]*\*\//,
+      value: (s) => s.substring(1),
+    },
+    string_literal: {
+      match: /"(?:[^\n\\"]|\\["\\ntbfr])*"/,
+      value: (s) => JSON.parse(s),
+    },
+    number_literal: {
+      match: /[0-9]+/,
+      value: (s) => Number(s),
+    },
+    identifier: {
+      match: /[a-z_A-Z][a-z_A-Z_0-9]*/,
+      type: moo.keywords({
+        array: "array",
+        vector: "vector",
+        struct: "struct",
+        tablle: "table",
+      }),
+    },
+  });
+
+  function tokenStart(token) {
+    return {
+      line: token.line,
+      col: token.col - 1,
+    };
+  }
+
+  function tokenEnd(token) {
+    const lastNewLine = token.text.lastIndexOf("\n");
+    if (lastNewLine !== -1) {
+      throw new Error("Unsupported case: token with line breaks");
+    }
+    return {
+      line: token.line,
+      col: token.col + token.text.length - 1,
+    };
+  }
+
+  function convertToken(token) {
+    return {
+      type: token.type,
+      value: token.value,
+      start: tokenStart(token),
+      end: tokenEnd(token),
+    };
+  }
+
+  function convertTokenId(data) {
+    return convertToken(data[0]);
+  }
+
+  var grammar = {
+    Lexer: lexer,
+    ParserRules: [
+      { name: "input", symbols: ["top_level_statements"], postprocess: id },
+      {
+        name: "top_level_statements",
+        symbols: ["_", "top_level_statement"],
+        postprocess: (d) => [d[1]],
+      },
+      {
+        name: "top_level_statements",
+        symbols: [
+          "_",
+          "top_level_statement",
+          "_",
+          { literal: "\n" },
+          "_",
+          "top_level_statements",
+        ],
+        postprocess: (d) => [d[1], ...d[5]],
+      },
+      {
+        name: "top_level_statements",
+        symbols: ["_", { literal: "\n" }, "top_level_statements"],
+        postprocess: (d) => d[2],
+      },
+      { name: "top_level_statements", symbols: ["_"], postprocess: (d) => [] },
+      {
+        name: "top_level_statement",
+        symbols: ["array_definition"],
+        postprocess: id,
+      },
+      {
+        name: "top_level_statement",
+        symbols: ["vector_definition"],
+        postprocess: id,
+      },
+      {
+        name: "top_level_statement",
+        symbols: ["option_definition"],
+        postprocess: id,
+      },
+      {
+        name: "top_level_statement",
+        symbols: ["union_definition"],
+        postprocess: id,
+      },
+      {
+        name: "top_level_statement",
+        symbols: ["struct_definition"],
+        postprocess: id,
+      },
+      {
+        name: "top_level_statement",
+        symbols: ["table_definition"],
+        postprocess: id,
+      },
+      {
+        name: "top_level_statement",
+        symbols: ["line_comment"],
+        postprocess: () => null,
+      },
+      {
+        name: "top_level_statement",
+        symbols: ["block_comment"],
+        postprocess: () => null,
+      },
+      {
+        name: "array_definition",
+        symbols: [
+          { literal: "array" },
+          "__",
+          "identifier",
+          "_",
+          "lbracket",
+          "_",
+          "identifier",
+          "_",
+          "semicolon",
+          "_",
+          "number",
+          "_",
+          "rbracket",
+          "_",
+          "semicolon",
+          "_",
+          "comment_opt",
+        ],
+        postprocess: function (data) {
+          return {
+            type: "array",
+            name: data[2].value,
+            item: data[6].value,
+            item_count: data[10].value,
+          };
+        },
+      },
+      {
+        name: "vector_definition",
+        symbols: [
+          { literal: "vector" },
+          "__",
+          "identifier",
+          "_",
+          "labracket",
+          "_",
+          "identifier",
+          "_",
+          "rabracket",
+          "_",
+          "semicolon",
+          "_",
+          "comment_opt",
+        ],
+        postprocess: function (data) {
+          return {
+            type: "vector",
+            name: data[2].value,
+            item: data[6].value,
+          };
+        },
+      },
+      {
+        name: "option_definition",
+        symbols: [
+          { literal: "option" },
+          "__",
+          "identifier",
+          "_",
+          "lparan",
+          "_",
+          "identifier",
+          "_",
+          "rparan",
+          "_",
+          "semicolon",
+          "_",
+          "comment_opt",
+        ],
+        postprocess: function (data) {
+          return {
+            type: "option",
+            name: data[2].value,
+            item: data[6].value,
+          };
+        },
+      },
+      {
+        name: "union_definition$ebnf$1$subexpression$1",
+        symbols: [
+          "multi_line_ws_char",
+          "_",
+          "identifier",
+          "_",
+          "comma",
+          "_",
+          "comment_opt",
+          "_",
+          "multi_line_ws_char",
+        ],
+      },
+      {
+        name: "union_definition$ebnf$1",
+        symbols: ["union_definition$ebnf$1$subexpression$1"],
+      },
+      {
+        name: "union_definition$ebnf$1$subexpression$2",
+        symbols: [
+          "multi_line_ws_char",
+          "_",
+          "identifier",
+          "_",
+          "comma",
+          "_",
+          "comment_opt",
+          "_",
+          "multi_line_ws_char",
+        ],
+      },
+      {
+        name: "union_definition$ebnf$1",
+        symbols: [
+          "union_definition$ebnf$1",
+          "union_definition$ebnf$1$subexpression$2",
+        ],
+        postprocess: function arrpush(d) {
+          return d[0].concat([d[1]]);
+        },
+      },
+      {
+        name: "union_definition",
+        symbols: [
+          { literal: "union" },
+          "__",
+          "identifier",
+          "_",
+          "lbrace",
+          "_",
+          "union_definition$ebnf$1",
+          "_",
+          "rbrace",
+        ],
+        postprocess: function (data) {
+          return {
+            type: "union",
+            name: data[2].value,
+            items: data[6].map((d) => d[2].value),
+          };
+        },
+      },
+      {
+        name: "struct_definition",
+        symbols: [
+          { literal: "struct" },
+          "__",
+          "identifier",
+          "_",
+          "block_definition",
+        ],
+        postprocess: function (data) {
+          return {
+            type: "struct",
+            name: data[2].value,
+            fields: data[4][2].map((d) => ({
+              name: d[2].value,
+              type: d[6].value,
+            })),
+          };
+        },
+      },
+      {
+        name: "table_definition",
+        symbols: [
+          { literal: "table" },
+          "__",
+          "identifier",
+          "_",
+          "block_definition",
+        ],
+        postprocess: function (data) {
+          return {
+            type: "table",
+            name: data[2].value,
+            fields: data[4][2].map((d) => ({
+              name: d[2].value,
+              type: d[6].value,
+            })),
+          };
+        },
+      },
+      {
+        name: "block_definition$ebnf$1$subexpression$1",
+        symbols: [
+          "multi_line_ws_char",
+          "_",
+          "identifier",
+          "_",
+          "colon",
+          "_",
+          "identifier",
+          "_",
+          "comma",
+          "_",
+          "comment_opt",
+          "_",
+          "multi_line_ws_char",
+        ],
+      },
+      {
+        name: "block_definition$ebnf$1",
+        symbols: ["block_definition$ebnf$1$subexpression$1"],
+      },
+      {
+        name: "block_definition$ebnf$1$subexpression$2",
+        symbols: [
+          "multi_line_ws_char",
+          "_",
+          "identifier",
+          "_",
+          "colon",
+          "_",
+          "identifier",
+          "_",
+          "comma",
+          "_",
+          "comment_opt",
+          "_",
+          "multi_line_ws_char",
+        ],
+      },
+      {
+        name: "block_definition$ebnf$1",
+        symbols: [
+          "block_definition$ebnf$1",
+          "block_definition$ebnf$1$subexpression$2",
+        ],
+        postprocess: function arrpush(d) {
+          return d[0].concat([d[1]]);
+        },
+      },
+      {
+        name: "block_definition",
+        symbols: ["lbrace", "_", "block_definition$ebnf$1", "_", "rbrace"],
+      },
+      { name: "comment_opt", symbols: ["line_comment"] },
+      { name: "comment_opt", symbols: ["block_comment"] },
+      { name: "comment_opt", symbols: [], postprocess: () => [] },
+      {
+        name: "line_comment",
+        symbols: [
+          lexer.has("line_comment") ? { type: "line_comment" } : line_comment,
+        ],
+        postprocess: id,
+      },
+      {
+        name: "block_comment",
+        symbols: [
+          lexer.has("block_comment")
+            ? { type: "block_comment" }
+            : block_comment,
+        ],
+        postprocess: id,
+      },
+      {
+        name: "string_literal",
+        symbols: [
+          lexer.has("string_literal")
+            ? { type: "string_literal" }
+            : string_literal,
+        ],
+        postprocess: convertTokenId,
+      },
+      {
+        name: "number",
+        symbols: [
+          lexer.has("number_literal")
+            ? { type: "number_literal" }
+            : number_literal,
+        ],
+        postprocess: convertTokenId,
+      },
+      {
+        name: "lbracket",
+        symbols: [lexer.has("lbracket") ? { type: "lbracket" } : lbracket],
+        postprocess: convertTokenId,
+      },
+      {
+        name: "rbracket",
+        symbols: [lexer.has("rbracket") ? { type: "rbracket" } : rbracket],
+        postprocess: convertTokenId,
+      },
+      {
+        name: "labracket",
+        symbols: [lexer.has("labracket") ? { type: "labracket" } : labracket],
+        postprocess: convertTokenId,
+      },
+      {
+        name: "rabracket",
+        symbols: [lexer.has("rabracket") ? { type: "rabracket" } : rabracket],
+        postprocess: convertTokenId,
+      },
+      {
+        name: "lparan",
+        symbols: [lexer.has("lparan") ? { type: "lparan" } : lparan],
+        postprocess: convertTokenId,
+      },
+      {
+        name: "rparan",
+        symbols: [lexer.has("rparan") ? { type: "rparan" } : rparan],
+        postprocess: convertTokenId,
+      },
+      {
+        name: "lbrace",
+        symbols: [lexer.has("lbrace") ? { type: "lbrace" } : lbrace],
+        postprocess: convertTokenId,
+      },
+      {
+        name: "rbrace",
+        symbols: [lexer.has("rbrace") ? { type: "rbrace" } : rbrace],
+        postprocess: convertTokenId,
+      },
+      {
+        name: "comma",
+        symbols: [lexer.has("comma") ? { type: "comma" } : comma],
+        postprocess: convertTokenId,
+      },
+      {
+        name: "colon",
+        symbols: [lexer.has("colon") ? { type: "colon" } : colon],
+        postprocess: convertTokenId,
+      },
+      {
+        name: "semicolon",
+        symbols: [lexer.has("semicolon") ? { type: "semicolon" } : semicolon],
+        postprocess: convertTokenId,
+      },
+      {
+        name: "identifier",
+        symbols: [
+          lexer.has("identifier") ? { type: "identifier" } : identifier,
+        ],
+        postprocess: convertTokenId,
+      },
+      { name: "_ml$ebnf$1", symbols: [] },
+      {
+        name: "_ml$ebnf$1",
+        symbols: ["_ml$ebnf$1", "multi_line_ws_char"],
+        postprocess: function arrpush(d) {
+          return d[0].concat([d[1]]);
+        },
+      },
+      { name: "_ml", symbols: ["_ml$ebnf$1"] },
+      {
+        name: "multi_line_ws_char",
+        symbols: [lexer.has("ws") ? { type: "ws" } : ws],
+      },
+      { name: "multi_line_ws_char", symbols: [{ literal: "\n" }] },
+      { name: "__$ebnf$1", symbols: [lexer.has("ws") ? { type: "ws" } : ws] },
+      {
+        name: "__$ebnf$1",
+        symbols: ["__$ebnf$1", lexer.has("ws") ? { type: "ws" } : ws],
+        postprocess: function arrpush(d) {
+          return d[0].concat([d[1]]);
+        },
+      },
+      { name: "__", symbols: ["__$ebnf$1"] },
+      { name: "_$ebnf$1", symbols: [] },
+      {
+        name: "_$ebnf$1",
+        symbols: ["_$ebnf$1", lexer.has("ws") ? { type: "ws" } : ws],
+        postprocess: function arrpush(d) {
+          return d[0].concat([d[1]]);
+        },
+      },
+      { name: "_", symbols: ["_$ebnf$1"] },
+    ],
+    ParserStart: "input",
+  };
+  if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
+    module.exports = grammar;
+  } else {
+    window.grammar = grammar;
+  }
+})();

--- a/packages/molecule/src/grammar/mol.ne
+++ b/packages/molecule/src/grammar/mol.ne
@@ -1,0 +1,220 @@
+
+# http://www.asciitable.com/
+@{%
+const moo = require("moo");
+
+const lexer = moo.compile({
+    ws: /[ \t]+/,
+    nl: { match: "\n", lineBreaks: true },
+    lparan: "(",
+    rparan: ")",
+    comma: ",",
+    lbracket: "[",
+    rbracket: "]",
+    lbrace: "{",
+    rbrace: "}",
+    labracket: "<",
+    rabracket: ">",
+    assignment: "=",
+    colon: ":",
+    semicolon: ";",
+    line_comment: {
+        match: /\/\/[^\n]*/,
+        value: s => s.substring(1)
+    },
+    block_comment: {
+        match: /\/\*[\w\d\s\n\t\r]*\*\//,
+        value: s => (s.substring(1))
+    },
+    string_literal: {
+        match: /"(?:[^\n\\"]|\\["\\ntbfr])*"/,
+        value: s => JSON.parse(s)
+    },
+    number_literal: {
+        match: /[0-9]+/,
+        value: s => Number(s)
+    },
+    identifier: {
+        match: /[a-z_A-Z][a-z_A-Z_0-9]*/,
+        type: moo.keywords({
+            array: "array",
+            vector: "vector",
+            struct: "struct",
+            tablle: "table",
+        })
+    }
+});
+
+
+function tokenStart(token) {
+    return {
+        line: token.line,
+        col: token.col - 1
+    };
+}
+
+function tokenEnd(token) {
+    const lastNewLine = token.text.lastIndexOf("\n");
+    if (lastNewLine !== -1) {
+        throw new Error("Unsupported case: token with line breaks");
+    }
+    return {
+        line: token.line,
+        col: token.col + token.text.length - 1
+    };
+}
+
+function convertToken(token) {
+    return {
+        type: token.type,
+        value: token.value,
+        start: tokenStart(token),
+        end: tokenEnd(token)
+    };
+}
+
+function convertTokenId(data) {
+    return convertToken(data[0]);
+}
+
+%}
+
+@lexer lexer
+
+input -> top_level_statements {% id %}
+
+top_level_statements
+    -> _ top_level_statement
+        {%
+            d => [d[1]]
+        %}
+    |  _ top_level_statement _ "\n" _ top_level_statements
+        {%
+            d => [
+                d[1],
+                ...d[5]
+            ]
+        %}
+    # below 2 sub-rules handle blank lines
+    |  _ "\n" top_level_statements
+        {%
+            d => d[2]
+        %}
+    |  _
+        {%
+            d => []
+        %}
+
+top_level_statement
+    -> array_definition   {% id %}
+    |  vector_definition  {% id %}
+    |  option_definition  {% id %}
+    |  union_definition  {% id %}
+    |  struct_definition  {% id %}
+    |  table_definition  {% id %}
+    |  line_comment     {% () => null %}
+    |  block_comment     {% () => null %}
+
+array_definition
+    -> "array" __ identifier _ lbracket _ identifier _ semicolon _ number _ rbracket _ semicolon _ comment_opt
+        {% 
+            function(data) {
+                return {
+                    type: "array",
+                    name: data[2].value,
+                    item:  data[6].value,
+                    item_count: data[10].value 
+                };
+            }
+        %}
+
+vector_definition
+     -> "vector" __ identifier _ labracket _ identifier _ rabracket _ semicolon _ comment_opt
+        {% 
+            function(data) {
+                return {
+                    type: "vector",
+                    name: data[2].value,
+                    item:  data[6].value,
+                };
+            }
+        %}
+
+option_definition
+     -> "option" __ identifier _ lparan _ identifier _ rparan _ semicolon _ comment_opt
+        {% 
+            function(data) {
+                return {
+                    type: "option",
+                    name: data[2].value,
+                    item:  data[6].value,
+                };
+            }
+        %}
+
+union_definition
+     -> "union" __ identifier _ lbrace _ (multi_line_ws_char _ identifier _ comma _ comment_opt _ multi_line_ws_char):+  _ rbrace
+        {% 
+            function(data) {
+                return {
+                    type: "union",
+                    name: data[2].value,
+                    items:  data[6].map(d => d[2].value),
+                };
+            }
+        %}
+
+struct_definition
+     -> "struct" __ identifier _ block_definition
+        {% 
+            function(data) {
+                return {
+                    type: "struct",
+                    name: data[2].value,
+                    fields:  data[4][2].map(d => ({name: d[2].value, type: d[6].value})),
+                };
+            }
+        %}
+
+table_definition
+     -> "table" __ identifier _ block_definition
+        {% 
+            function(data) {
+                return {
+                    type: "table",
+                    name: data[2].value,
+                    fields:  data[4][2].map(d => ({name: d[2].value, type: d[6].value})),
+                };
+            }
+        %}
+
+block_definition
+     -> lbrace _ (multi_line_ws_char _ identifier _ colon _ identifier _ comma _ comment_opt _ multi_line_ws_char):+  _ rbrace
+
+comment_opt -> line_comment | block_comment | null {% () => ([]) %}
+line_comment -> %line_comment {% id %}
+block_comment -> %block_comment {% id %}
+string_literal -> %string_literal {% convertTokenId %}
+number -> %number_literal {% convertTokenId %}
+lbracket -> %lbracket {% convertTokenId %}
+rbracket -> %rbracket {% convertTokenId %}
+labracket -> %labracket {% convertTokenId %}
+rabracket -> %rabracket {% convertTokenId %}
+lparan -> %lparan {% convertTokenId %}
+rparan -> %rparan {% convertTokenId %}
+lbrace -> %lbrace {% convertTokenId %}
+rbrace -> %rbrace {% convertTokenId %}
+comma -> %comma {% convertTokenId %}
+colon -> %colon {% convertTokenId %}
+semicolon -> %semicolon {% convertTokenId %}
+identifier -> %identifier {% convertTokenId %}
+
+_ml -> multi_line_ws_char:*
+
+multi_line_ws_char
+    -> %ws
+    |  "\n"
+
+__ -> %ws:+
+
+_ -> %ws:*

--- a/packages/molecule/src/index.ts
+++ b/packages/molecule/src/index.ts
@@ -1,0 +1,4 @@
+export { createParser } from "./nearley";
+export { createCodecMap } from "./codec";
+export { toMolTypeMap } from "./utils";
+export type { Parser, CodecMap, MolTypeMap, MolType } from "./type";

--- a/packages/molecule/src/nearley.ts
+++ b/packages/molecule/src/nearley.ts
@@ -1,0 +1,142 @@
+import { Parser as NearleyParser, Grammar as NearleyGrammar } from "nearley";
+import {
+  Struct,
+  Vector,
+  Union,
+  Array,
+  Table,
+  Field,
+  MolType,
+  MolTypeMap,
+  Parser,
+  ParseOptions,
+} from "./type";
+import { nonNull, toMolTypeMap } from "./utils";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const grammar = require("./grammar/mol.js");
+
+export const createParser = (): Parser => {
+  return {
+    parse: (
+      data,
+      options: ParseOptions = {
+        skipDependenciesCheck: false,
+      }
+    ) => {
+      const parser = new NearleyParser(NearleyGrammar.fromCompiled(grammar));
+      parser.feed(data);
+      const results = parser.results[0].filter(
+        (result: MolType | null) => !!result
+      ) as MolType[];
+      validateParserResults(results, options);
+      return results;
+    },
+  };
+};
+/**
+ * primitive type
+ */
+export const byte = "byte";
+
+const validateParserResults = (results: MolType[], options: ParseOptions) => {
+  checkDuplicateNames(results);
+  if (!options.skipDependenciesCheck) {
+    checkDependencies(results);
+  }
+};
+
+const checkDuplicateNames = (results: MolType[]) => {
+  const names = new Set<string>();
+  results.forEach((result) => {
+    const currentName = result.name;
+    if (names.has(currentName)) {
+      throw new Error(`Duplicate name: ${currentName}`);
+    }
+    names.add(currentName);
+    const currentType = result.type;
+    // check duplicate field names in `struct` and `table`
+    if (currentType === "struct" || currentType === "table") {
+      const fieldNames = new Set<string>();
+      (result as Struct).fields.forEach((field: Field) => {
+        const currentFieldName = field.name;
+        if (fieldNames.has(currentFieldName)) {
+          throw new Error(`Duplicate field name: ${currentFieldName}`);
+        }
+        fieldNames.add(currentFieldName);
+      });
+    }
+  });
+};
+const checkDependencies = (results: MolType[]) => {
+  const map = toMolTypeMap(results);
+  for (const entry of map) {
+    const molItem = map.get(entry[0])!;
+    nonNull(molItem);
+    const type = molItem.type;
+    switch (type) {
+      case "array":
+      case "struct": {
+        assertFixedMolType(molItem.name, map);
+        break;
+      }
+      case "vector":
+      case "option": {
+        if ((molItem as Vector).item !== byte) {
+          nonNull(map.get((molItem as Vector).item));
+        }
+        break;
+      }
+      case "union": {
+        const unionDeps = (molItem as Union).items;
+        unionDeps.forEach((dep: string) => {
+          if (dep !== byte) {
+            nonNull(map.get(dep));
+          }
+        });
+        break;
+      }
+      case "table": {
+        const tableDeps = (molItem as Table).fields.map(
+          (field: Field) => field.type
+        );
+        tableDeps.forEach((dep: string) => {
+          if (dep !== byte) {
+            nonNull(map.get(dep));
+          }
+        });
+        break;
+      }
+      default:
+        break;
+    }
+  }
+};
+
+/**
+ * mol type `array` and `struct` should have fixed byte length
+ */
+const assertFixedMolType = (name: string, map: MolTypeMap) => {
+  const molItem = map.get(name)!;
+  nonNull(molItem);
+  const type = molItem.type;
+  switch (type) {
+    case "array": {
+      if ((molItem as Array).item !== byte) {
+        assertFixedMolType(molItem.name, map);
+      }
+      break;
+    }
+    case "struct": {
+      const fields = (molItem as Struct).fields;
+      fields.forEach((field: Field) => {
+        if (field.type !== byte) {
+          assertFixedMolType(field.type, map);
+        }
+      });
+      break;
+    }
+    default:
+      throw new Error(`Type ${name} should be fixed length.`);
+  }
+};

--- a/packages/molecule/src/type.ts
+++ b/packages/molecule/src/type.ts
@@ -1,0 +1,60 @@
+import { AnyCodec } from "@ckb-lumos/codec/lib/base";
+export const byte = "byte";
+
+export type BaseType = {
+  name: string;
+  item: string;
+};
+
+export type Field = {
+  name: string;
+  type: string;
+};
+
+export type Array = {
+  type: "array";
+  item_count: number;
+} & BaseType;
+
+export type Vector = {
+  type: "vector";
+} & BaseType;
+
+export type Option = {
+  type: "option";
+} & BaseType;
+
+export type Union = {
+  type: "union";
+  name: string;
+  items: string[];
+};
+
+export type Struct = {
+  type: "struct";
+  name: string;
+  fields: Field[];
+};
+
+export type Table = {
+  type: "table";
+  name: string;
+  fields: Field[];
+};
+
+// mol types
+export type MolType = Array | Vector | Option | Union | Struct | Table;
+
+// key is type name
+export type MolTypeMap = Map<string, MolType>;
+
+// key is type name
+export type CodecMap = Map<string, AnyCodec>;
+
+export type ParseOptions = {
+  skipDependenciesCheck: boolean;
+};
+
+export interface Parser {
+  parse(data: string, options?: ParseOptions): MolType[];
+}

--- a/packages/molecule/src/utils.ts
+++ b/packages/molecule/src/utils.ts
@@ -1,0 +1,16 @@
+import { MolType, MolTypeMap } from "./type";
+
+// TODO: assert not null/undefined
+export function nonNull(data: unknown): void {
+  if (!data) {
+    throw new Error(`${data} does not exist.`);
+  }
+}
+
+export const toMolTypeMap = (results: MolType[]): MolTypeMap => {
+  const map = new Map<string, MolType>();
+  results.forEach((result) => {
+    map.set(result.name, result);
+  });
+  return map;
+};

--- a/packages/molecule/tests/codec.test.ts
+++ b/packages/molecule/tests/codec.test.ts
@@ -1,0 +1,535 @@
+import test from "ava";
+import { deepHexifyBI } from "@ckb-lumos/codec/lib/utils";
+import { blockchain } from "@ckb-lumos/base";
+import { toMolTypeMap } from "../src/utils";
+import { CodecMap, MolType } from "../src/type";
+import { createCodecMap } from "../src/codec";
+import { BI } from "@ckb-lumos/bi";
+
+test("test codec", (t) => {
+  const tokens: MolType[] = [
+    { item: "byte", item_count: 1, name: "Uint8", type: "array" },
+  ];
+  const codecMap = createCodecMap(toMolTypeMap(tokens));
+  t.truthy(codecMap.get("Uint8")!.unpack("0x01") === 1);
+  t.truthy(codecMap.get("Uint8")!.unpack("0xff") === 255);
+});
+
+test("test codec with refs", (t) => {
+  const tokens: MolType[] = [
+    { item: "Bytes", name: "BytesVec", type: "vector" },
+  ];
+  const refs: CodecMap = new Map([["Bytes", blockchain.Bytes]]);
+  const codecMap = createCodecMap(tokens, refs);
+  t.deepEqual(
+    codecMap.get("BytesVec")!.unpack("0x0e00000008000000020000001234"),
+    ["0x1234"]
+  );
+});
+
+// https://github.com/nervosnetwork/ckb/blob/5a7efe7a0b720de79ff3761dc6e8424b8d5b22ea/util/types/schemas/blockchain.mol
+const ast: MolType[] = [
+  { type: "array", name: "Uint32", item: "byte", item_count: 4 },
+  { type: "array", name: "Uint64", item: "byte", item_count: 8 },
+  { type: "array", name: "Uint128", item: "byte", item_count: 16 },
+  { type: "array", name: "Byte32", item: "byte", item_count: 32 },
+  { type: "array", name: "Uint256", item: "byte", item_count: 32 },
+  { type: "vector", name: "Bytes", item: "byte" },
+  { type: "option", name: "BytesOpt", item: "Bytes" },
+  { type: "vector", name: "BytesVec", item: "Bytes" },
+  { type: "vector", name: "Byte32Vec", item: "Byte32" },
+  { type: "option", name: "ScriptOpt", item: "Script" },
+  { type: "array", name: "ProposalShortId", item: "byte", item_count: 10 },
+  { type: "vector", name: "UncleBlockVec", item: "UncleBlock" },
+  { type: "vector", name: "TransactionVec", item: "Transaction" },
+  { type: "vector", name: "ProposalShortIdVec", item: "ProposalShortId" },
+  { type: "vector", name: "CellDepVec", item: "CellDep" },
+  { type: "vector", name: "CellInputVec", item: "CellInput" },
+  { type: "vector", name: "CellOutputVec", item: "CellOutput" },
+  {
+    type: "table",
+    name: "Script",
+    fields: [
+      { name: "codeHash", type: "Byte32" },
+      { name: "hashType", type: "byte" },
+      { name: "args", type: "Bytes" },
+    ],
+  },
+  {
+    type: "struct",
+    name: "OutPoint",
+    fields: [
+      { name: "txHash", type: "Byte32" },
+      { name: "index", type: "Uint32" },
+    ],
+  },
+  {
+    type: "struct",
+    name: "CellInput",
+    fields: [
+      { name: "since", type: "Uint64" },
+      { name: "previousOutput", type: "OutPoint" },
+    ],
+  },
+  {
+    type: "table",
+    name: "CellOutput",
+    fields: [
+      { name: "capacity", type: "Uint64" },
+      { name: "lock", type: "Script" },
+      { name: "type", type: "ScriptOpt" },
+    ],
+  },
+  {
+    type: "struct",
+    name: "CellDep",
+    fields: [
+      { name: "outPoint", type: "OutPoint" },
+      { name: "depType", type: "byte" },
+    ],
+  },
+  {
+    type: "table",
+    name: "RawTransaction",
+    fields: [
+      { name: "version", type: "Uint32" },
+      { name: "cellDeps", type: "CellDepVec" },
+      { name: "headerDeps", type: "Byte32Vec" },
+      { name: "inputs", type: "CellInputVec" },
+      { name: "outputs", type: "CellOutputVec" },
+      { name: "outputsData", type: "BytesVec" },
+    ],
+  },
+  {
+    type: "table",
+    name: "Transaction",
+    fields: [
+      { name: "raw", type: "RawTransaction" },
+      { name: "witnesses", type: "BytesVec" },
+    ],
+  },
+  {
+    type: "struct",
+    name: "RawHeader",
+    fields: [
+      { name: "version", type: "Uint32" },
+      { name: "compactTarget", type: "Uint32" },
+      { name: "timestamp", type: "Uint64" },
+      { name: "number", type: "Uint64" },
+      { name: "epoch", type: "Uint64" },
+      { name: "parentHash", type: "Byte32" },
+      { name: "transactionsRoot", type: "Byte32" },
+      { name: "proposalsHash", type: "Byte32" },
+      { name: "extraHash", type: "Byte32" },
+      { name: "dao", type: "Byte32" },
+    ],
+  },
+  {
+    type: "struct",
+    name: "Header",
+    fields: [
+      { name: "raw", type: "RawHeader" },
+      { name: "nonce", type: "Uint128" },
+    ],
+  },
+  {
+    type: "table",
+    name: "UncleBlock",
+    fields: [
+      { name: "header", type: "Header" },
+      { name: "proposals", type: "ProposalShortIdVec" },
+    ],
+  },
+  {
+    type: "table",
+    name: "Block",
+    fields: [
+      { name: "header", type: "Header" },
+      { name: "uncles", type: "UncleBlockVec" },
+      { name: "transactions", type: "TransactionVec" },
+      { name: "proposals", type: "ProposalShortIdVec" },
+    ],
+  },
+  {
+    type: "table",
+    name: "BlockV1",
+    fields: [
+      { name: "header", type: "Header" },
+      { name: "uncles", type: "UncleBlockVec" },
+      { name: "transactions", type: "TransactionVec" },
+      { name: "proposals", type: "ProposalShortIdVec" },
+      { name: "extension", type: "Bytes" },
+    ],
+  },
+  {
+    type: "table",
+    name: "CellbaseWitness",
+    fields: [
+      { name: "lock", type: "Script" },
+      { name: "message", type: "Bytes" },
+    ],
+  },
+  {
+    type: "table",
+    name: "WitnessArgs",
+    fields: [
+      { name: "lock", type: "BytesOpt" },
+      { name: "inputType", type: "BytesOpt" },
+      { name: "outputType", type: "BytesOpt" },
+    ],
+  },
+];
+const codecMap = createCodecMap(toMolTypeMap(ast));
+// below test cases come from:
+// https://github.com/ckb-js/lumos/blob/e33aaa10d831edd58e904cb2215ea3148c37fba3/packages/base/tests/serialize.test.ts
+test("should unpack Script", (t) => {
+  t.deepEqual(
+    codecMap
+      .get("Script")!
+      .unpack(
+        "0x3d0000001000000030000000310000009bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce80108000000aabbccdd44332211"
+      ),
+    {
+      args: "0xaabbccdd44332211",
+      codeHash:
+        "0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+      hashType: "0x01",
+    }
+  );
+});
+test("should unpack OutPoint", (t) => {
+  t.deepEqual(
+    codecMap
+      .get("OutPoint")!
+      .unpack(
+        "0x4565f957aa65ca5d094ede05cbeaedcee70f5a71200ae2e31b643d2952c929bc03000000"
+      ),
+    {
+      txHash:
+        "0x4565f957aa65ca5d094ede05cbeaedcee70f5a71200ae2e31b643d2952c929bc",
+      index: 3,
+    }
+  );
+});
+test("should unpack CellInput", (t) => {
+  t.deepEqual(
+    deepHexifyBI(
+      codecMap
+        .get("CellInput")!
+        .unpack(
+          "0x341200a060000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da10000000"
+        )
+    ),
+    deepHexifyBI({
+      since: BI.from("0x60a0001234"),
+      previousOutput: {
+        txHash:
+          "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da",
+        index: 16,
+      },
+    })
+  );
+});
+
+test("should unpack CellOutput", (t) => {
+  t.deepEqual(
+    deepHexifyBI(
+      codecMap
+        .get("CellOutput")!
+        .unpack(
+          "0x8400000010000000180000004f000000100000000000000037000000100000003000000031000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da0002000000123435000000100000003000000031000000a98c57135830e1b900000000f6c4b8870828199a786b26f09f7dec4bc27a73db0100000000"
+        )
+    ),
+    deepHexifyBI({
+      capacity: BI.from("0x10"),
+      lock: {
+        codeHash:
+          "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da",
+        args: "0x1234",
+        hashType: "0x00",
+      },
+      type: {
+        codeHash:
+          "0xa98c57135830e1b900000000f6c4b8870828199a786b26f09f7dec4bc27a73db",
+        args: "0x",
+        hashType: "0x01",
+      },
+    })
+  );
+});
+
+test("should unpack CellOutput without type", (t) => {
+  t.deepEqual(
+    deepHexifyBI(
+      codecMap
+        .get("CellOutput")!
+        .unpack(
+          "0x4f00000010000000180000004f000000100000000000000037000000100000003000000031000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da00020000001234"
+        )
+    ),
+    deepHexifyBI({
+      capacity: BI.from("0x10"),
+      lock: {
+        codeHash:
+          "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da",
+        args: "0x1234",
+        hashType: "0x00",
+      },
+      type: undefined,
+    })
+  );
+});
+
+test("should unpack CellDep", (t) => {
+  t.deepEqual(
+    codecMap
+      .get("CellDep")!
+      .unpack(
+        "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da1100000000"
+      ),
+    {
+      depType: "0x00",
+      outPoint: {
+        txHash:
+          "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73da",
+        index: 17,
+      },
+    }
+  );
+});
+test("should unpack Transaction", (t) => {
+  t.deepEqual(
+    deepHexifyBI(
+      codecMap
+        .get("Transaction")!
+        .unpack(
+          "0x1f0100000c0000000f010000030100001c00000020000000490000006d0000009d000000f40000000000000001000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7300000000000001000000b39d53656421d1532dd995a0924441ca8f43052bc2b7740a0e814a488a8214d6010000001000000000000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73010200000057000000080000004f00000010000000180000004f000000341200000000000037000000100000003000000031000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7302000200000012340f0000000800000003000000abcdef10000000080000000400000031313131"
+        )
+    ),
+    deepHexifyBI({
+      raw: {
+        version: 0,
+        cellDeps: [
+          {
+            depType: "0x00",
+            outPoint: {
+              txHash:
+                "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7300",
+              index: 0,
+            },
+          },
+        ],
+        headerDeps: [
+          "0xb39d53656421d1532dd995a0924441ca8f43052bc2b7740a0e814a488a8214d6",
+        ],
+        inputs: [
+          {
+            since: BI.from("0x10"),
+            previousOutput: {
+              txHash:
+                "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7301",
+              index: 2,
+            },
+          },
+        ],
+        outputs: [
+          {
+            capacity: BI.from("0x1234"),
+            lock: {
+              codeHash:
+                "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7302",
+              args: "0x1234",
+              hashType: "0x00",
+            },
+            type: undefined,
+          },
+        ],
+        outputsData: ["0xabcdef"],
+      },
+      witnesses: ["0x31313131"],
+    })
+  );
+});
+
+test("should unpack Header", (t) => {
+  t.deepEqual(
+    deepHexifyBI(
+      codecMap
+        .get("Header")!
+        .unpack(
+          "0x0000000094342d1ac363a6ab70010000bcb10f000000000087020012060807003134874027b9b2b17391d2fa545344b10bd8b8c49d9ea47d55a447d01142b21b68a83c880eb942396d22020aa83343906986f66418e9b8a4488f2866ecc4e86a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040b4d9a3ddc9e730736c7342a2f023001240f362253b780000b6ca2f1e7901070001a084150000001a13af4950389b44"
+        )
+    ),
+    deepHexifyBI({
+      nonce: BI.from("0x449b385049af131a0000001584a00100"),
+      raw: {
+        compactTarget: 439170196,
+        number: BI.from("0xfb1bc"),
+        parentHash:
+          "0x3134874027b9b2b17391d2fa545344b10bd8b8c49d9ea47d55a447d01142b21b",
+        timestamp: BI.from("0x170aba663c3"),
+        transactionsRoot:
+          "0x68a83c880eb942396d22020aa83343906986f66418e9b8a4488f2866ecc4e86a",
+        proposalsHash:
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+        extraHash:
+          "0x0000000000000000000000000000000000000000000000000000000000000000",
+        version: 0,
+        epoch: BI.from("0x7080612000287"),
+        dao: "0x40b4d9a3ddc9e730736c7342a2f023001240f362253b780000b6ca2f1e790107",
+      },
+    })
+  );
+});
+
+test("should unpack UncleBlock", (t) => {
+  t.deepEqual(
+    deepHexifyBI(
+      codecMap
+        .get("UncleBlock")!
+        .unpack(
+          "0xf40000000c000000dc0000000000000094342d1ac363a6ab70010000bcb10f000000000087020012060807003134874027b9b2b17391d2fa545344b10bd8b8c49d9ea47d55a447d01142b21b68a83c880eb942396d22020aa83343906986f66418e9b8a4488f2866ecc4e86a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040b4d9a3ddc9e730736c7342a2f023001240f362253b780000b6ca2f1e7901070001a084150000001a13af4950389b440200000012345678901234567890abcdeabcdeabcdeabcde"
+        )
+    ),
+    deepHexifyBI({
+      header: {
+        nonce: BI.from("0x449b385049af131a0000001584a00100"),
+        raw: {
+          compactTarget: 439170196,
+          number: BI.from("0xfb1bc"),
+          parentHash:
+            "0x3134874027b9b2b17391d2fa545344b10bd8b8c49d9ea47d55a447d01142b21b",
+          timestamp: BI.from("0x170aba663c3"),
+          transactionsRoot:
+            "0x68a83c880eb942396d22020aa83343906986f66418e9b8a4488f2866ecc4e86a",
+          proposalsHash:
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+          extraHash:
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+          version: 0,
+          epoch: BI.from("0x7080612000287"),
+          dao: "0x40b4d9a3ddc9e730736c7342a2f023001240f362253b780000b6ca2f1e790107",
+        },
+      },
+      proposals: ["0x12345678901234567890", "0xabcdeabcdeabcdeabcde"],
+    })
+  );
+});
+
+test("should unpack Block", (t) => {
+  t.deepEqual(
+    deepHexifyBI(
+      codecMap
+        .get("Block")!
+        .unpack(
+          "0x2502000014000000e4000000e80000000d0200000000000094342d1ac363a6ab70010000bcb10f000000000087020012060807003134874027b9b2b17391d2fa545344b10bd8b8c49d9ea47d55a447d01142b21b68a83c880eb942396d22020aa83343906986f66418e9b8a4488f2866ecc4e86a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040b4d9a3ddc9e730736c7342a2f023001240f362253b780000b6ca2f1e7901070001a084150000001a13af4950389b440400000025010000080000001d0100000c0000000f010000030100001c00000020000000490000006d0000009d000000f40000000000000001000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7300000000000001000000b39d53656421d1532dd995a0924441ca8f43052bc2b7740a0e814a488a8214d6010000001000000000000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a73010200000057000000080000004f00000010000000180000004f000000341200000000000037000000100000003000000031000000a98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7302000200000012340f0000000800000003000000abcdef0e000000080000000200000011110200000012345678901234567890abcdeabcdeabcdeabcde"
+        )
+    ),
+    deepHexifyBI({
+      header: {
+        nonce: BI.from("0x449b385049af131a0000001584a00100"),
+        raw: {
+          compactTarget: 439170196,
+          number: BI.from("0xfb1bc"),
+          parentHash:
+            "0x3134874027b9b2b17391d2fa545344b10bd8b8c49d9ea47d55a447d01142b21b",
+          timestamp: BI.from("0x170aba663c3"),
+          transactionsRoot:
+            "0x68a83c880eb942396d22020aa83343906986f66418e9b8a4488f2866ecc4e86a",
+          proposalsHash:
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+          extraHash:
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+          version: 0,
+          epoch: BI.from("0x7080612000287"),
+          dao: "0x40b4d9a3ddc9e730736c7342a2f023001240f362253b780000b6ca2f1e790107",
+        },
+      },
+      proposals: ["0x12345678901234567890", "0xabcdeabcdeabcdeabcde"],
+      transactions: [
+        {
+          raw: {
+            version: 0,
+            cellDeps: [
+              {
+                depType: "0x00",
+                outPoint: {
+                  txHash:
+                    "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7300",
+                  index: 0,
+                },
+              },
+            ],
+            headerDeps: [
+              "0xb39d53656421d1532dd995a0924441ca8f43052bc2b7740a0e814a488a8214d6",
+            ],
+            inputs: [
+              {
+                since: BI.from("0x10"),
+                previousOutput: {
+                  txHash:
+                    "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7301",
+                  index: 2,
+                },
+              },
+            ],
+            outputs: [
+              {
+                capacity: BI.from("0x1234"),
+                lock: {
+                  codeHash:
+                    "0xa98c57135830e1b91345948df6c4b8870828199a786b26f09f7dec4bc27a7302",
+                  args: "0x1234",
+                  hashType: "0x00",
+                },
+                type: undefined,
+              },
+            ],
+            outputsData: ["0xabcdef"],
+          },
+          witnesses: ["0x1111"],
+        },
+      ],
+      uncles: [],
+    })
+  );
+});
+
+test("should unpack WitnessArgs", (t) => {
+  t.deepEqual(
+    codecMap
+      .get("WitnessArgs")!
+      .unpack(
+        "0x2200000010000000160000001c000000020000001234020000004678020000002312"
+      ),
+    {
+      lock: "0x1234",
+      inputType: "0x4678",
+      outputType: "0x2312",
+    }
+  );
+});
+
+test("should unpack empty WitnessArgs", (t) => {
+  t.deepEqual(
+    codecMap.get("WitnessArgs")!.unpack("0x10000000100000001000000010000000"),
+    {
+      lock: undefined,
+      inputType: undefined,
+      outputType: undefined,
+    }
+  );
+});
+
+test("should unpack only one WitnessArgs", (t) => {
+  t.deepEqual(
+    codecMap
+      .get("WitnessArgs")!
+      .unpack("0x16000000100000001600000016000000020000001234"),
+    {
+      lock: "0x1234",
+      inputType: undefined,
+      outputType: undefined,
+    }
+  );
+});

--- a/packages/molecule/tests/grammar.test.ts
+++ b/packages/molecule/tests/grammar.test.ts
@@ -1,0 +1,287 @@
+import test from "ava";
+import { createParser } from "../src";
+
+test("should parse sample", (t) => {
+  const parser = createParser();
+  const result = parser.parse(`
+    /* Basic Types */
+    array Uint8 [byte; 1]; // one byte Uint
+  `);
+  t.deepEqual(result, [
+    { item: "byte", item_count: 1, name: "Uint8", type: "array" },
+  ]);
+});
+test("should parse blockchain.mol", (t) => {
+  const parser = createParser();
+  // https://github.com/nervosnetwork/ckb/blob/5a7efe7a0b720de79ff3761dc6e8424b8d5b22ea/util/types/schemas/blockchain.mol
+  const result = parser.parse(`
+  /* Basic Types */
+
+  // as a byte array in little endian.
+  array Uint32 [byte; 4];
+  array Uint64 [byte; 8];
+  array Uint128 [byte; 16];
+  array Byte32 [byte; 32];
+  array Uint256 [byte; 32];
+
+  vector Bytes <byte>;
+  option BytesOpt (Bytes);
+
+  vector BytesVec <Bytes>;
+  vector Byte32Vec <Byte32>;
+
+  /* Types for Chain */
+
+  option ScriptOpt (Script);
+
+  array ProposalShortId [byte; 10];
+
+  vector UncleBlockVec <UncleBlock>;
+  vector TransactionVec <Transaction>;
+  vector ProposalShortIdVec <ProposalShortId>;
+  vector CellDepVec <CellDep>;
+  vector CellInputVec <CellInput>;
+  vector CellOutputVec <CellOutput>;
+
+  table Script {
+      code_hash:      Byte32,
+      hash_type:      byte,
+      args:           Bytes,
+  }
+
+  struct OutPoint {
+      tx_hash:        Byte32,
+      index:          Uint32,
+  }
+
+  struct CellInput {
+      since:           Uint64,
+      previous_output: OutPoint,
+  }
+
+  table CellOutput {
+      capacity:       Uint64,
+      lock:           Script,
+      type_:          ScriptOpt,
+  }
+
+  struct CellDep {
+      out_point:      OutPoint,
+      dep_type:       byte,
+  }
+
+  table RawTransaction {
+      version:        Uint32,
+      cell_deps:      CellDepVec,
+      header_deps:    Byte32Vec,
+      inputs:         CellInputVec,
+      outputs:        CellOutputVec,
+      outputs_data:   BytesVec,
+  }
+
+  table Transaction {
+      raw:            RawTransaction,
+      witnesses:      BytesVec,
+  }
+
+  struct RawHeader {
+      version:                Uint32,
+      compact_target:         Uint32,
+      timestamp:              Uint64,
+      number:                 Uint64,
+      epoch:                  Uint64,
+      parent_hash:            Byte32,
+      transactions_root:      Byte32,
+      proposals_hash:         Byte32,
+      extra_hash:             Byte32,
+      dao:                    Byte32,
+  }
+
+  struct Header {
+      raw:                    RawHeader,
+      nonce:                  Uint128,
+  }
+
+  table UncleBlock {
+      header:                 Header,
+      proposals:              ProposalShortIdVec,
+  }
+
+  table Block {
+      header:                 Header,
+      uncles:                 UncleBlockVec,
+      transactions:           TransactionVec,
+      proposals:              ProposalShortIdVec,
+  }
+
+  table BlockV1 {
+      header:                 Header,
+      uncles:                 UncleBlockVec,
+      transactions:           TransactionVec,
+      proposals:              ProposalShortIdVec,
+      extension:              Bytes,
+  }
+
+  table CellbaseWitness {
+      lock:    Script,
+      message: Bytes,
+  }
+
+  table WitnessArgs {
+      lock:                   BytesOpt,          // Lock args
+      input_type:             BytesOpt,          // Type args for input
+      output_type:            BytesOpt,          // Type args for output
+  }
+  `);
+  t.deepEqual(result, [
+    { type: "array", name: "Uint32", item: "byte", item_count: 4 },
+    { type: "array", name: "Uint64", item: "byte", item_count: 8 },
+    { type: "array", name: "Uint128", item: "byte", item_count: 16 },
+    { type: "array", name: "Byte32", item: "byte", item_count: 32 },
+    { type: "array", name: "Uint256", item: "byte", item_count: 32 },
+    { type: "vector", name: "Bytes", item: "byte" },
+    { type: "option", name: "BytesOpt", item: "Bytes" },
+    { type: "vector", name: "BytesVec", item: "Bytes" },
+    { type: "vector", name: "Byte32Vec", item: "Byte32" },
+    { type: "option", name: "ScriptOpt", item: "Script" },
+    { type: "array", name: "ProposalShortId", item: "byte", item_count: 10 },
+    { type: "vector", name: "UncleBlockVec", item: "UncleBlock" },
+    { type: "vector", name: "TransactionVec", item: "Transaction" },
+    { type: "vector", name: "ProposalShortIdVec", item: "ProposalShortId" },
+    { type: "vector", name: "CellDepVec", item: "CellDep" },
+    { type: "vector", name: "CellInputVec", item: "CellInput" },
+    { type: "vector", name: "CellOutputVec", item: "CellOutput" },
+    {
+      type: "table",
+      name: "Script",
+      fields: [
+        { name: "code_hash", type: "Byte32" },
+        { name: "hash_type", type: "byte" },
+        { name: "args", type: "Bytes" },
+      ],
+    },
+    {
+      type: "struct",
+      name: "OutPoint",
+      fields: [
+        { name: "tx_hash", type: "Byte32" },
+        { name: "index", type: "Uint32" },
+      ],
+    },
+    {
+      type: "struct",
+      name: "CellInput",
+      fields: [
+        { name: "since", type: "Uint64" },
+        { name: "previous_output", type: "OutPoint" },
+      ],
+    },
+    {
+      type: "table",
+      name: "CellOutput",
+      fields: [
+        { name: "capacity", type: "Uint64" },
+        { name: "lock", type: "Script" },
+        { name: "type_", type: "ScriptOpt" },
+      ],
+    },
+    {
+      type: "struct",
+      name: "CellDep",
+      fields: [
+        { name: "out_point", type: "OutPoint" },
+        { name: "dep_type", type: "byte" },
+      ],
+    },
+    {
+      type: "table",
+      name: "RawTransaction",
+      fields: [
+        { name: "version", type: "Uint32" },
+        { name: "cell_deps", type: "CellDepVec" },
+        { name: "header_deps", type: "Byte32Vec" },
+        { name: "inputs", type: "CellInputVec" },
+        { name: "outputs", type: "CellOutputVec" },
+        { name: "outputs_data", type: "BytesVec" },
+      ],
+    },
+    {
+      type: "table",
+      name: "Transaction",
+      fields: [
+        { name: "raw", type: "RawTransaction" },
+        { name: "witnesses", type: "BytesVec" },
+      ],
+    },
+    {
+      type: "struct",
+      name: "RawHeader",
+      fields: [
+        { name: "version", type: "Uint32" },
+        { name: "compact_target", type: "Uint32" },
+        { name: "timestamp", type: "Uint64" },
+        { name: "number", type: "Uint64" },
+        { name: "epoch", type: "Uint64" },
+        { name: "parent_hash", type: "Byte32" },
+        { name: "transactions_root", type: "Byte32" },
+        { name: "proposals_hash", type: "Byte32" },
+        { name: "extra_hash", type: "Byte32" },
+        { name: "dao", type: "Byte32" },
+      ],
+    },
+    {
+      type: "struct",
+      name: "Header",
+      fields: [
+        { name: "raw", type: "RawHeader" },
+        { name: "nonce", type: "Uint128" },
+      ],
+    },
+    {
+      type: "table",
+      name: "UncleBlock",
+      fields: [
+        { name: "header", type: "Header" },
+        { name: "proposals", type: "ProposalShortIdVec" },
+      ],
+    },
+    {
+      type: "table",
+      name: "Block",
+      fields: [
+        { name: "header", type: "Header" },
+        { name: "uncles", type: "UncleBlockVec" },
+        { name: "transactions", type: "TransactionVec" },
+        { name: "proposals", type: "ProposalShortIdVec" },
+      ],
+    },
+    {
+      type: "table",
+      name: "BlockV1",
+      fields: [
+        { name: "header", type: "Header" },
+        { name: "uncles", type: "UncleBlockVec" },
+        { name: "transactions", type: "TransactionVec" },
+        { name: "proposals", type: "ProposalShortIdVec" },
+        { name: "extension", type: "Bytes" },
+      ],
+    },
+    {
+      type: "table",
+      name: "CellbaseWitness",
+      fields: [
+        { name: "lock", type: "Script" },
+        { name: "message", type: "Bytes" },
+      ],
+    },
+    {
+      type: "table",
+      name: "WitnessArgs",
+      fields: [
+        { name: "lock", type: "BytesOpt" },
+        { name: "input_type", type: "BytesOpt" },
+        { name: "output_type", type: "BytesOpt" },
+      ],
+    },
+  ]);
+});

--- a/packages/molecule/tsconfig.json
+++ b/packages/molecule/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3355,6 +3355,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
+"@types/nearley@^2.11.2":
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/@types/nearley/-/nearley-2.11.2.tgz#ddd716fa4b9ab15acec51d39b7524709d4dd5cc8"
+  integrity sha512-jeyIDNBxxyWyEk6HemDC+t32b4fxthVsgWDxf88qD2WpX0QpOyY8JvA80AElPTBGRUsO0EKnr6OeVOjK3ZDdnA==
+
 "@types/node@*", "@types/node@>=12":
   version "18.6.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.1.tgz#828e4785ccca13f44e2fb6852ae0ef11e3e20ba5"
@@ -4807,7 +4812,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0, commander@^2.8.1:
+commander@^2.19.0, commander@^2.20.0, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -5488,6 +5493,11 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -8683,6 +8693,11 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+moo@^0.5.0, moo@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
+  integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -8765,6 +8780,16 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+nearley@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.20.1.tgz#246cd33eff0d012faf197ff6774d7ac78acdd474"
+  integrity sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
 
 negotiator@0.6.3, negotiator@^0.6.2:
   version "0.6.3"
@@ -9850,6 +9875,19 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -10225,6 +10263,11 @@ restore-cursor@^3.1.0:
   dependencies:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
+
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
 retry@^0.12.0:
   version "0.12.0"


### PR DESCRIPTION
# Description

This PR provides an easy way to translate molecule schema to codecs. More deep motivations please refer to #402 

## Usage

```ts
// molecule schema
const mol = "array Uint8 [byte; 1];\narray Uint32 [byte; 4];"

// translate schema to codecs
import { createParser, createCodecMap } from "@ckb-lumos/molecule"
const tokens = createParser().parse(mol)
const codecMap = createCodecMap(tokens)

// decode
codecMap.get("Uint8").unpack("0x01")
codecMap.get("Uint32").unpack("0x01020304")
```

Fixes #402 

This PR introduces a new npm package: `@ckb-lumos/molecule` 

demo website: https://lumos-website-git-fork-zhangyouxin-molecule-cryptape.vercel.app/tools/molecule-parser
demo usage: https://github.com/zhangyouxin/lumos/blob/b3c9ad0486a7b945a82b6ff67c7b15a471d945ea/website/src/components/molecule-parser/Molecule.tsx#L55-L65

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation or Website


# How Has This Been Tested?

- [x] Unit Test for parsing schema to token
- [x] Unit Test for parsing token to codecs
